### PR TITLE
Check package installation errors (bnc#913906)

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 27 13:34:34 UTC 2015 - lslezak@suse.cz
+
+- check package installation errors (e.g. the PHP package is
+  included in the Web and Scripting SLE12 module which is optional
+  and might not be available), do not fail silently (bnc#913906)
+- 3.1.5
+
+-------------------------------------------------------------------
 Tue Jan 20 12:41:59 UTC 2015 - jsrain@suse.cz
 
 - check for manually created files in order to prevent data loss

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/http-server/complex.rb
+++ b/src/include/http-server/complex.rb
@@ -48,7 +48,7 @@ module Yast
         "boolean ()"
       )
       ret = HttpServer.Write
-      ret ? :next : :abort
+      ret ? :next : :back
     end
 
     # Abort dialog ask user for abort application

--- a/src/modules/HttpServer.rb
+++ b/src/modules/HttpServer.rb
@@ -485,7 +485,7 @@ module Yast
       rpms = YaPI::HTTPD.GetModulePackages
 
       # install required RPMs for modules
-      Package.InstallAllMsg(
+      installed = Package.InstallAllMsg(
         rpms,
         _(
           "The enabled modules require\n" +
@@ -494,6 +494,11 @@ module Yast
             "Install them now?\n"
         )
       )
+
+      if !installed
+        Report.Error(Message.FailedToInstallPackages)
+        return false
+      end
 
       # write httpd.conf
 


### PR DESCRIPTION
- The PHP package is included in the Web and Scripting SLE12 module (repository) which is optional and might not be available, the installation might fail in some cases.

- Go back if package installation fails at `Write` (to not lose the changes).

- 3.1.5