### PR TITLE
Replace SuSEFirewall2 by Firewalld (bsc#1071548)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Makefile.am.common
 .dep
 *.ybc
 *.ami
+/.yardoc
+/doc
+testsuite/raw.tmp.err.*

--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 23 07:28:19 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld. (fate#323460)
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Mar 15 14:27:23 UTC 2017 - ancor@suse.com
 
 - Create a backup at startup of the vhost configuration files to

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        3.2.2
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -27,10 +27,10 @@ Group:          System/YaST
 License:        GPL-2.0
 BuildRequires:	yast2-network docbook-xsl-stylesheets doxygen libxslt perl-XML-Writer popt-devel sgml-skel update-desktop-files yast2-packagemanager-devel yast2-perl-bindings yast2-testsuite libzio
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2 >= 3.1.118
+BuildRequires:  yast2 >= 4.0.38
 Requires:	yast2-network yast2-perl-bindings libzio
-# FileChanges.created_files (bsc#1027582)
-Requires:       yast2 >= 3.2.16
+# SuSEFirewall2 replaced by firewalld yast2.rpm (fate#323460)
+Requires:       yast2 >= 4.0.38
 
 BuildArchitectures:	noarch
 

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -30,7 +30,7 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2 >= 4.0.36
 Requires:	yast2-network yast2-perl-bindings libzio
 # SuSEFirewall2 replaced by firewalld yast2.rpm (fate#323460)
-Requires:       yast2 >= 4.0.38
+Requires:       yast2 >= 4.0.39
 
 BuildArchitectures:	noarch
 

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -27,7 +27,7 @@ Group:          System/YaST
 License:        GPL-2.0
 BuildRequires:	yast2-network docbook-xsl-stylesheets doxygen libxslt perl-XML-Writer popt-devel sgml-skel update-desktop-files yast2-packagemanager-devel yast2-perl-bindings yast2-testsuite libzio
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2 >= 4.0.38
+BuildRequires:  yast2 >= 4.0.36
 Requires:	yast2-network yast2-perl-bindings libzio
 # SuSEFirewall2 replaced by firewalld yast2.rpm (fate#323460)
 Requires:       yast2 >= 4.0.38

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -30,7 +30,6 @@ module Yast
       Yast.import "HttpServer"
       Yast.import "YaST::HTTPDData"
       Yast.import "Confirm"
-      Yast.import "SuSEFirewall"
       Yast.import "CWMServiceStart"
       Yast.import "CWMFirewallInterfaces"
       Yast.import "Punycode"
@@ -370,12 +369,15 @@ module Yast
           ),
           "handle_events" => ["enabled", "disabled"],
           "opt"           => [:notify],
-          "help"          => Ops.get_string(@HELPS, "server_enable", "")
+          "help"          => @HELPS["server_enable"]
         },
         "firewall_adapt"    => CWMFirewallInterfaces.CreateOpenFirewallWidget(
           {
-            "services"        => ["service:apache2", "service:apache2-ssl"],
-            "help"            => Ops.get_string(@HELPS, "firewall_adapt", ""),
+            # Firewalld already defines the http and https services. This
+            # module modifies the service adding custom ports, taking that in
+            # account we will continue using apache2 and apache2-ssl.
+            "services"        => ["apache2", "apache2-ssl"],
+            "help"            => @HELPS["firewall_adapt"],
             "display_details" => true
           }
         ),

--- a/src/modules/YaPI/HTTPD.pm
+++ b/src/modules/YaPI/HTTPD.pm
@@ -85,13 +85,13 @@ CreateListen($fromPort,$toPort,$address,$doFirewall)
 
   $fromPort and $toPort are the listen ports. They can be the same.
   $address is the bind address and can be an empty string for 'all'
-  $doFirewall is a boolean to write the listen data to the SuSEFirewall2
+  $doFirewall is a boolean to write the listen data to firewalld
 
 DeleteListen($fromPort,$toPort,$address,$doFirewall)
 
   $fromPort and $toPort are the listen ports. They can be the same.
   $address is the bind address and can be an empty string for 'all'
-  $doFirewall is a boolean to delete the listen data from the SuSEFirewall2
+  $doFirewall is a boolean to delete the listen data from firewalld
 
 $curListen = GetCurrentListen()
 
@@ -306,7 +306,7 @@ use Data::Dumper;
 @YaPI::HTTPD::ISA = qw( YaPI YaST::httpdUtils YaST::HTTPDData );
 YaST::YCP::Import ("SCR");
 YaST::YCP::Import ("Service");
-YaST::YCP::Import ("SuSEFirewall");
+YaST::YCP::Import ("FirewalldWrapper");
 textdomain "http-server";
 
 #######################################################
@@ -1236,8 +1236,8 @@ with this function you can configure the addresses and ports
 the webserver is listening on. $fromPort and $toPort can have
 the same value. $listen must be a network interface of the
 host but can be an empty string for 'all' interfaces.
-The $doFirewall boolean indicates if the SuSEFirewall2 shall
-be configured for the settings.
+The $doFirewall boolean indicates if 'firewalld' shall be
+configured for the settings.
 
 EXAMPLE
 
@@ -1272,12 +1272,12 @@ y2warning("SCR::WRITE listentries", Dumper(\@listenEntries), "new entry ", Dumpe
     if( $doFirewall ) {
         my $ip2device = $self->ip2device();
         my $if = exists($newEntry{ADDRESS})?$ip2device->{$newEntry{ADDRESS}}:'all';
-        SuSEFirewall->Read();
-        unless( SuSEFirewall->AddService( $newEntry{PORT}, "TCP", $if ) ) {
+        FirewalldWrapper->read();
+        unless( FirewalldWrapper->add_port( $newEntry{PORT}, "TCP", $if ) ) {
             return $self->SetError( code    => 'SET_FW_FAILED',
                                     summary => __('writing the firewall rules failed') );
         } else {
-            SuSEFirewall->Write();
+            FirewalldWrapper->write();
         }
     }
     return 1;
@@ -1291,8 +1291,8 @@ the webserver is listening on. $fromPort and $toPort can have
 the same value. $listen must be a network interface of the
 host but can be an empty string for 'all' interfaces.
 If the listen parameter can't be found, undef is returned.
-The $doFirewall boolean indicates if the SuSEFirewall2 shall
-be configured for the settings.
+The $doFirewall boolean indicates if firewalld shall be
+configured for the settings.
 
 EXAMPLE
 
@@ -1330,9 +1330,9 @@ sub DeleteListen {
         my $ip2device = $self->ip2device();
         my $if = $ip?$ip2device->{$ip}:'all';
         my $port = ($fromPort eq $toPort)?($fromPort):("$fromPort-$toPort");
-        SuSEFirewall->Read();
-        SuSEFirewall->RemoveService( $port, "TCP", $if );
-        SuSEFirewall->Write();
+        FirewalldWrapper->read();
+        FirewallWrapper->remove_port( $port, "TCP", $if );
+        FirewalldWrapper->write();
     }
     return 1;
 }

--- a/src/modules/YaST/httpdUtils.pm
+++ b/src/modules/YaST/httpdUtils.pm
@@ -3,7 +3,7 @@ use YaST::YCP;
 use YaPI;
 textdomain "http-server";
 
-YaST::YCP::Import ("SuSEFirewall");
+YaST::YCP::Import ("FirewalldWrapper");
 YaST::YCP::Import ("NetworkInterfaces");
 YaST::YCP::Import ("Progress");
 YaST::YCP::Import ("SCR");
@@ -154,7 +154,7 @@ sub ip2device {
     my $self = shift;
     my %ip2device;
     Progress->off();
-    SuSEFirewall->Read();
+    FirewalldWrapper->read();
     NetworkInterfaces->Read();
     my $devices = NetworkInterfaces->Locate("BOOTPROTO", "static");
     foreach my $dev ( @$devices ) {


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)
- It needs yast/yast-yast2#674


## When firewalld services are not available
![notfoundservice](https://user-images.githubusercontent.com/7056681/35336714-3341031e-0111-11e8-9f2b-fa4e2bd4ac5f.png)

## When firewalld services are available then (Complete Workflow):

![enableapache2dmz](https://user-images.githubusercontent.com/7056681/35337656-b3f45d92-0113-11e8-88ab-67086d2cbca7.png)
![summaryofchannges](https://user-images.githubusercontent.com/7056681/35337660-b5700d4c-0113-11e8-829f-0d92cdfe97e3.png)
![firewallcmdchecks](https://user-images.githubusercontent.com/7056681/35337950-7de75adc-0114-11e8-90cc-60eb57d4975b.png)