### PR TITLE
Fixed typo in the function published return type

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  9 23:11:29 UTC 2018 - knut.anderssen@suse.com
+
+- Fixed typo in published HttpServerWidgets widget function return 
+  type (bsc#1092155)
+- 4.0.2
+
+-------------------------------------------------------------------
 Thu May  3 07:34:15 UTC 2018 - knut.anderssen@suse.com
 
 - Do not cache the widgets definition until it is really needed to

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -3651,7 +3651,7 @@ module Yast
     publish :function => :initVhostDetails, :type => "void (string)"
     publish :function => :handleVhostDetails, :type => "symbol (string, map)"
     publish :function => :storeVhostDetails, :type => "void (string, map)"
-    publish :function => :widgets, :type => "map <string, map <string, any>>"
+    publish :function => :widgets, :type => "map (string, map <string, any>)"
     publish :function => :listen2item, :type => "term (map <string, any>, integer)"
   end
 


### PR DESCRIPTION
It was introduced in #27 