### PR TITLE
Replace PHP5 by PHP7 (bsc#1099106)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-http-server-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-http-server-image ./travis_package_check.sh

--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 14 11:04:38 UTC 2018 - lslezak@suse.cz
+
+- Fixed PHP support (use PHP7 instead of dropped PHP5)
+  (bsc#1099106)
+- Fixed also the other renamed packages (for Python and apparmor)
+- 4.0.2
+
+-------------------------------------------------------------------
 Thu Jun 28 10:47:18 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/http-server/wizard-dialog.rb
+++ b/src/include/http-server/wizard-dialog.rb
@@ -171,7 +171,7 @@ module Yast
         # add selected modules to that list
         YaST::HTTPDData.ModifyModuleList(["php#{YaST::HTTPDData.PhpVersion}"], enable_php)
         YaST::HTTPDData.ModifyModuleList(["perl"], enable_perl)
-        YaST::HTTPDData.ModifyModuleList(["python"], enable_python)
+        YaST::HTTPDData.ModifyModuleList(["wsgi-python3"], enable_python)
         #        YaST::HTTPDData::ModifyModuleList ([ "ruby" ], enable_ruby);
 
         HttpServer.modified = true

--- a/src/include/http-server/wizard-dialog.rb
+++ b/src/include/http-server/wizard-dialog.rb
@@ -145,8 +145,8 @@ module Yast
         { :abort => fun_ref(method(:ReallyAbort), "boolean ()") }
       )
       if ret == :next
-        enable_php5 = Convert.to_boolean(
-          UI.QueryWidget(Id(:scr_mod_php5), :Value)
+        enable_php = Convert.to_boolean(
+          UI.QueryWidget(Id(:scr_mod_php), :Value)
         )
         enable_perl = Convert.to_boolean(
           UI.QueryWidget(Id(:scr_mod_perl), :Value)
@@ -157,7 +157,7 @@ module Yast
         #        boolean enable_ruby=(boolean) UI::QueryWidget( `id(`scr_mod_ruby), `Value );
 
         Builtins.y2milestone("Saving script modules")
-        Builtins.y2milestone("PHP5 support %1", enable_php5)
+        Builtins.y2milestone("PHP support %1", enable_php)
         Builtins.y2milestone("Perl support %1", enable_perl)
         Builtins.y2milestone("Python support %1", enable_python)
         #	y2milestone("Ruby support %1", enable_ruby);
@@ -169,7 +169,7 @@ module Yast
           )
         end
         # add selected modules to that list
-        YaST::HTTPDData.ModifyModuleList(["php5"], enable_php5)
+        YaST::HTTPDData.ModifyModuleList(["php#{YaST::HTTPDData.PhpVersion}"], enable_php)
         YaST::HTTPDData.ModifyModuleList(["perl"], enable_perl)
         YaST::HTTPDData.ModifyModuleList(["python"], enable_python)
         #        YaST::HTTPDData::ModifyModuleList ([ "ruby" ], enable_ruby);

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -3501,15 +3501,10 @@ module Yast
       end
     end
     def initScriptModules(key)
-      enable_php5 = false
-      enable_perl = false
-      enable_python = false
-      #	boolean enable_ruby=false;
       modules = YaST::HTTPDData.GetModuleList
-      enable_php5 = true if Builtins.contains(modules, "php5")
-      enable_perl = true if Builtins.contains(modules, "perl")
-      enable_python = true if Builtins.contains(modules, "python")
-      #	if (contains(modules, "ruby")) enable_ruby = true;
+      enable_php = Builtins.contains(modules, "php#{YaST::HTTPDData.PhpVersion}")
+      enable_perl = Builtins.contains(modules, "perl")
+      enable_python = Builtins.contains(modules, "python")
 
       UI.ReplaceWidget(
         Id(:scr_mod_replace),
@@ -3519,9 +3514,9 @@ module Yast
             VSpacing(3), #translators: checkbox - support for php script language
             Left(
               CheckBox(
-                Id(:scr_mod_php5),
-                _("Enable &PHP5 Scripting"),
-                enable_php5
+                Id(:scr_mod_php),
+                _("Enable &PHP Scripting"),
+                enable_php
               )
             ),
             VSpacing(1), #translators: checkbox - support for perl script language

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -3502,9 +3502,9 @@ module Yast
     end
     def initScriptModules(key)
       modules = YaST::HTTPDData.GetModuleList
-      enable_php = Builtins.contains(modules, "php#{YaST::HTTPDData.PhpVersion}")
-      enable_perl = Builtins.contains(modules, "perl")
-      enable_python = Builtins.contains(modules, "python")
+      enable_php = modules.include?("php#{YaST::HTTPDData.PhpVersion}")
+      enable_perl = modules.include?("perl")
+      enable_python = modules.include?("wsgi-python3")
 
       UI.ReplaceWidget(
         Id(:scr_mod_replace),

--- a/src/modules/YaPI/HTTPDModules.pm
+++ b/src/modules/YaPI/HTTPDModules.pm
@@ -1,5 +1,6 @@
 package YaPI::HTTPDModules;
 use YaPI;
+use YaST::HTTPDData;
 textdomain "http-server";
 %modules = (
 # (without_leading mod_) module name = {
@@ -706,9 +707,9 @@ textdomain "http-server";
                                    { option =>"VirtualScriptAliasIP",     "context" => [ "Server", "Virtual", "Directory" ] }
 				]
     },
-    'php5' => {
-                    summary   => __("Provides support for PHP5 dynamically generated pages"),
-                    packages  => ["apache2-mod_php5"],
+    'php' . YaST::HTTPDData->PhpVersion() => {
+                    summary   => __("Provides support for PHP dynamically generated pages"),
+                    packages  => ["apache2-mod_php" . YaST::HTTPDData->PhpVersion()],
                     default   => 0,
                     position  => 490
     },

--- a/src/modules/YaPI/HTTPDModules.pm
+++ b/src/modules/YaPI/HTTPDModules.pm
@@ -719,15 +719,15 @@ textdomain "http-server";
                     default   => 0,
                     position  => 500
     },
-    'python' => {
+    'wsgi-python3' => {
                     summary   => __("Provides support for Python dynamically generated pages"),
-                    packages  => ["apache2-mod_python"],
+                    packages  => ["apache2-mod_wsgi-python3"],
                     default   => 0,
                     position  => 510
     },
     'apparmor' => {
                     summary   => __("Provides support for AppArmor subprocess confinement within apache"),
-                    packages  => ["mod-apparmor"],
+                    packages  => ["apache2-mod_apparmor"],
                     default   => 0,
                     position  => 530
      },

--- a/src/modules/YaST/HTTPDData.pm
+++ b/src/modules/YaST/HTTPDData.pm
@@ -23,6 +23,12 @@ sub SetError {
     return YaPI::HTTPD->SetError( @_ );
 }
 
+# Define globally the current PHP version
+BEGIN { $TYPEINFO{PhpVersion} = ["function", "string" ]; }
+sub PhpVersion {
+    return "7";
+}
+
 BEGIN { $TYPEINFO{Error} = ["function", [ "map", "string", "string" ] ]; }
 sub Error {
     return YaPI::HTTPD->Error();

--- a/testsuite/tests/getCurrentListen.rb
+++ b/testsuite/tests/getCurrentListen.rb
@@ -10,8 +10,8 @@ module Yast
       @READ = { "http_server" => { "listen" => ["80", "127.0.0.1:99"] } }
       TESTSUITE_INIT([@READ, {}, {}], nil)
 
-      Yast.import "YaST::HTTPDData"
       Yast.import "YaPI::HTTPD"
+      Yast.import "YaST::HTTPDData"
 
 
       TEST(lambda { YaST::HTTPDData.ReadListen }, [@READ, {}, {}], nil)

--- a/testsuite/tests/parseDirOption.rb
+++ b/testsuite/tests/parseDirOption.rb
@@ -7,6 +7,7 @@ module Yast
     def main
       Yast.include self, "testsuite.rb"
 
+      Yast.import "YaPI::HTTPD"
       Yast.import "YaST::HTTPDData"
 
       TEST(lambda do

--- a/testsuite/tests/readHosts.rb
+++ b/testsuite/tests/readHosts.rb
@@ -190,8 +190,8 @@ module Yast
 
       TESTSUITE_INIT([@READ, {}, {}], nil)
 
-      Yast.import "YaST::HTTPDData"
       Yast.import "YaPI::HTTPD"
+      Yast.import "YaST::HTTPDData"
 
 
       TEST(lambda { YaST::HTTPDData.ReadHosts }, [@READ, {}, {}], nil)

--- a/testsuite/tests/readListen.rb
+++ b/testsuite/tests/readListen.rb
@@ -10,8 +10,8 @@ module Yast
       @READ = { "http_server" => { "listen" => ["80", "127.0.0.1:99"] } }
       TESTSUITE_INIT([@READ, {}, {}], nil)
 
-      Yast.import "YaST::HTTPDData"
       Yast.import "YaPI::HTTPD"
+      Yast.import "YaST::HTTPDData"
 
       TEST(lambda { YaST::HTTPDData.ReadListen }, [@READ, {}, {}], nil)
 

--- a/travis_package_check.rb
+++ b/travis_package_check.rb
@@ -1,0 +1,47 @@
+#! /usr/bin/env ruby
+
+require "yast"
+
+Yast.import "YaPI::HTTPD"
+Yast.import "YaST::HTTPDData"
+Yast.import "Pkg"
+
+#
+# Initialize the package manager
+#
+def init_pkg
+    # Initialize the target
+    Yast::Pkg.TargetInitialize("/")
+    # Load the installed packages into the pool.
+    Yast::Pkg.TargetLoad
+    # Load the repository configuration. Refreshes the repositories if needed.
+    Yast::Pkg.SourceRestore
+    # Load the available packages in the repositories to the pool.
+    Yast::Pkg.SourceLoad
+end
+
+#
+# Collect all needed packages
+#
+# @return [Array<String>] package list
+#
+def apache_packages
+    packages = Yast::YaST::HTTPDData.GetKnownModules.reduce([]) do |acc, m|
+        acc.concat(m["packages"])
+    end
+    packages.uniq
+end
+
+puts "Checking the package availability..."
+puts
+
+init_pkg
+packages = apache_packages
+
+success = packages.reduce(true) do |acc, p|
+    available = Yast::Pkg.PkgAvailable(p)
+    puts "Package #{p} " + (available ? "OK" : "missing!")
+    acc &&= available
+end
+
+exit(1) unless success

--- a/travis_package_check.sh
+++ b/travis_package_check.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+set -e
+make -f Makefile.cvs
+make install
+./travis_package_check.rb


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1099106
- Replace PHP5 by PHP7
- Define the PHP version globally so we have to change only this single place next time.
- The version number has been removed from UI to be consistent with the other languages (for Python or Perl we also do not display the versions)
- Checked all packages mentioned in [HTTPDModules.pm](https://github.com/yast/yast-http-server/blob/SLE-15-GA/src/modules/YaPI/HTTPDModules.pm)
- Fixed also `apache2-mod_python` -> `apache2-mod_wsgi-python3`
- Fixed also `mod-apparmor` -> `apache2-mod_apparmor`
- Added an automatic check in Travis to check whether all required packages are still available (later I'll enable running the check for master regularly once a week from the Travis cron)
- See the [example Travis output](https://travis-ci.org/yast/yast-http-server/jobs/415930869#L941)

## Test

- Tested manually
- Enabled the PHP support, the PHP7 packages were correctly installed
- Created testing `/srv/www/htdocs/index.php` document with simple
  ```php
  <?php
  phpinfo();
  ?>
  ```
  testing content, accessing the http://localhost/ page displayed the PHP info correctly.