### PR TITLE
Fix "cannot import namespace HttpData"

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct  4 08:48:05 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- Really import the missing namespace (bsc#1148763, bsc#1145538)
+- 4.2.2
+
+-------------------------------------------------------------------
 Mon Aug 19 12:00:46 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#114553 

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - HTTP Server Configuration
 Group:          System/YaST

--- a/src/clients/http-server.rb
+++ b/src/clients/http-server.rb
@@ -26,7 +26,7 @@ module Yast
       Yast.import "Hostname"
       Yast.import "HttpServerWidgets"
       Yast.import "HttpServer"
-      Yast.import "HTTPDData"
+      Yast.import "YaST::HTTPDData"
 
       Yast.include self, "http-server/wizards.rb"
 


### PR DESCRIPTION
- https://trello.com/c/DMPCXbZs
- https://bugzilla.suse.com/show_bug.cgi?id=1148763

### Testing

- I have tested the fix manually in Tumbleweed.
- old-testsuite tests pass at build time
- there are no RSpec tests
    - part of the module is in Perl, yay!
- openQA does integration testing (they reported the bug)