### PR TITLE
Drop rclinks

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 13 13:16:28 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- replace rcsymlink by direct systemd call (jsc#SLE-10976)
+- 4.2.4
+
+-------------------------------------------------------------------
 Tue Oct 15 07:51:21 UTC 2019 - Martin Vidner <mvidner@suse.com>
 
 - Add tests for the previous fix (bsc#1148763, bsc#1145538)
@@ -13,7 +19,7 @@ Fri Oct  4 08:48:05 UTC 2019 - Martin Vidner <mvidner@suse.com>
 -------------------------------------------------------------------
 Mon Aug 19 12:00:46 UTC 2019 - Michal Filka <mfilka@suse.com>
 
-- bnc#114553 
+- bnc#114553
   - loaded missing namespace to avoid internal error
 - 4.2.1
 

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - HTTP Server Configuration
 Group:          System/YaST

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -1000,7 +1000,7 @@ module Yast
 
     # Reload server
     def ReloadServer
-      SCR.Execute(path(".target.bash"), "/usr/sbin/rcapache2 reload")
+      SCR.Execute(path(".target.bash"), "/bin/systemctl reload apache2")
 
       nil
     end


### PR DESCRIPTION
trello: https://trello.com/c/Cx9X2roJ/1472-3-get-rid-of-etc-initd-and-sbin-rc-calls

motivation preparation for dropping of init.d and rc symlinks and use systemctl everywhere.