### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:48:47 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.5
+
+-------------------------------------------------------------------
 Mon Jan 13 13:16:28 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - replace rcsymlink by direct systemd call (jsc#SLE-10976)

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - HTTP Server Configuration
 Group:          System/YaST

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -1000,7 +1000,7 @@ module Yast
 
     # Reload server
     def ReloadServer
-      SCR.Execute(path(".target.bash"), "/bin/systemctl reload apache2")
+      SCR.Execute(path(".target.bash"), "/usr/bin/systemctl reload apache2")
 
       nil
     end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.