### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 17:37:21 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu Jan 23 12:48:47 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - don't use /bin/systemctl compat symlink (bsc#1160890)

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - HTTP Server Configuration
 Group:          System/YaST

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -926,7 +926,7 @@ module Yast
       if Builtins.size(servername) == 0
         if hostid == "main"
           Report.Warning(
-            _("When no Server name is defined, hostname will be used instead.")
+            _("When no server name is defined, the hostname will be used instead.")
           )
           return true
         else

--- a/src/modules/YaPI/HTTPD.pm
+++ b/src/modules/YaPI/HTTPD.pm
@@ -783,7 +783,7 @@ if( $key->{KEY} =~ /ServerTokens|TimeOut|ExtendedStatus/ ) {
     # already exists check
     foreach my $hostHash ( @{$vhost_files->{'yast2_vhosts.conf'}} ) {
         if( exists($hostHash->{HOSTID}) and $hostHash->{HOSTID} eq $hostid ) {
-            return $self->SetError( summary => __('hostid already exists'), code => "CHECK_PARAM_FAILED" );
+            return $self->SetError( summary => __('Host ID already exists'), code => "CHECK_PARAM_FAILED" );
         }
     }
 
@@ -843,7 +843,7 @@ sub DeleteHost {
             $found = 1;
         }
     }
-    return $self->SetError( summary => __('hostid not found'), code => "CHECK_PARAM_FAILED" ) unless( $found );
+    return $self->SetError( summary => __('Host ID not found'), code => "CHECK_PARAM_FAILED" ) unless( $found );
     if( @newList ) {
         $vhost_files->{$filename} = \@newList;
     } else {


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.


#### en_US.po File

```po
# English message file for YaST2 (@memory@).
# Copyright (C) 2005 SUSE Linux Products GmbH.
# Copyright (C) 2002 SuSE Linux AG.
#
msgid ""
msgstr ""
"Project-Id-Version: YaST (@memory@)\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2019-10-16 02:28+0000\n"
"PO-Revision-Date: 2002-07-18 14:04+0200\n"
"Last-Translator: proofreader <i18n@suse.de>\n"
"Language-Team: English <i18n@suse.de>\n"
"Language: en_US\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=n != 1;"

#. for apache2.2 ServerName is not forced (if not - hostname will be used)
#: src/modules/HttpServerWidgets.rb:929
msgid "When no Server name is defined, hostname will be used instead."
msgstr "When no server name is defined, the hostname will be used instead."

#: src/modules/YaPI/HTTPD.pm:786
msgid "hostid already exists"
msgstr "Host ID already exists"

#: src/modules/YaPI/HTTPD.pm:846
msgid "hostid not found"
msgstr "Host ID not found"
```
