### PR TITLE
Default restart

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  4 08:24:20 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Propose to restart the http service as the default action when it
+  is running (bsc#1165638)
+- 4.1.5
+
+-------------------------------------------------------------------
 Fri Feb 22 07:51:52 UTC 2019 - mfilka@suse.com
 
 - bnc#1119455

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.1.4
+Version:        4.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/HttpServerWidgets.rb
+++ b/src/modules/HttpServerWidgets.rb
@@ -765,7 +765,9 @@ module Yast
     #
     # @return [::CWM::ServiceWidget]
     def service_widget
-      @service_widget ||= ::CWM::ServiceWidget.new(HttpServer.service)
+      @service_widget = ::CWM::ServiceWidget.new(HttpServer.service)
+      @service_widget.default_action = :restart if HttpServer.service&.running?
+      @service_widget
     end
 
     # Validate certificate


### PR DESCRIPTION
## Problem

When the new service widget was [introduced](https://trello.com/c/uAe4i9Ru/107-5-fate319428-allow-socket-activation-widget), the default action when writing the modified configuration was to `keep the current state`, that basically means **do not touch the service**.

That was not the default action in **SLE-12** for some of the modules that use the new service widget, at least it is not the case of this module.

For that reason, in previous sprint it was agreed to change the default action, using `reload` (when supported) or `restart` when the service was **active** and `keep_the_current_state` when it was **inactive**. (see https://github.com/yast/yast-yast2/pull/1001)

The apache2 service supports the `reload` action and therefore it is the **proposed default action** which is not exactly the same that is proposed in SLE-12-X (it is [restart](https://github.com/yast/yast-http-server/blob/SLE-12-SP5/src/modules/HttpServer.rb#L496))

- https://trello.com/c/0iBBEqsF/1635-8-check-all-listed-modules-whether-the-new-servicewidget-default-action-is-the-correct-one
- https://bugzilla.suse.com/show_bug.cgi?id=1165638

## Solution

- Propose **restart** as the default service widget action in case the service is running.