### PR TITLE
Query php version dynamically

### DIFF
--- a/package/yast2-http-server.changes
+++ b/package/yast2-http-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 27 09:43:03 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- bsc#1200016
+  - find out php version dynamically to avoid hardcoded version
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-http-server.spec
+++ b/package/yast2-http-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-http-server
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - HTTP Server Configuration
 License:        GPL-2.0-only

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,8 @@
 
 module_DATA = \
   modules/HttpServer.rb \
-  modules/HttpServerWidgets.rb
+  modules/HttpServerWidgets.rb \
+  modules/HttpServerPackages.rb
 
 module1dir = @moduledir@/YaPI
 module1_DATA = \

--- a/src/modules/HttpServer.rb
+++ b/src/modules/HttpServer.rb
@@ -181,6 +181,7 @@ module Yast
       return false if !NetworkService.ConfirmNetworkManager
       Progress.NextStep
 
+      init_packager
 
       # check rpms
       required = deep_copy(@required_packages)
@@ -842,6 +843,14 @@ module Yast
     publish :function => :AutoPackages, :type => "map ()"
 
   private
+
+    # Makes sure the package database is initialized.
+    def init_packager
+      Pkg.TargetInitialize(Installation.destdir)
+      Pkg.TargetLoad
+      Pkg.SourceRestore
+      Pkg.SourceLoad
+    end
 
     def backup_vhost_config
       return if @vhost_files_to_backup.empty?

--- a/src/modules/HttpServer.rb
+++ b/src/modules/HttpServer.rb
@@ -41,6 +41,7 @@ module Yast
       Yast.import "FileChanges"
       Yast.import "Label"
       Yast.import "Mode"
+      Yast.import "PackageSystem"
 
       # Abort function
       # return boolean return true if abort
@@ -846,10 +847,8 @@ module Yast
 
     # Makes sure the package database is initialized.
     def init_packager
-      Pkg.TargetInitialize(Installation.destdir)
-      Pkg.TargetLoad
-      Pkg.SourceRestore
-      Pkg.SourceLoad
+      PackageSystem.EnsureTargetInit
+      PackageSystem.EnsureSourceInit
     end
 
     def backup_vhost_config

--- a/src/modules/HttpServer.rb
+++ b/src/modules/HttpServer.rb
@@ -226,8 +226,6 @@ module Yast
         return false
       end
 
-
-
       Progress.NextStep
 
 

--- a/src/modules/HttpServerPackages.rb
+++ b/src/modules/HttpServerPackages.rb
@@ -40,7 +40,7 @@ module Yast
       # NOTE: - Resolvable.find takes POSIX regexp, later select uses Ruby regexp
       # - Resolvable.find supports regexps only for dependencies, so we need to
       # filter result according to package name
-      Y2Packager::Resolvable.find({ kind: :package, provides_regexp: "^#{pattern}$" }, [])
+      Y2Packager::Resolvable.find( kind: :package, provides_regexp: "^#{pattern}$")
         .select { |p| p.name =~ /\A#{pattern}\z/ }
         .map(&:name)
         .uniq

--- a/src/modules/HttpServerPackages.rb
+++ b/src/modules/HttpServerPackages.rb
@@ -37,8 +37,6 @@ module Yast
     def by_pattern(pattern)
       raise ArgumentError, "Missing search pattern" if pattern.nil? || pattern.empty?
 
-      init_packager
-
       # NOTE: - Resolvable.find takes POSIX regexp, later select uses Ruby regexp
       # - Resolvable.find supports regexps only for dependencies, so we need to
       # filter result according to package name
@@ -50,14 +48,6 @@ module Yast
 
     publish function: :by_pattern, type: "list <string> (string)"
 
-  private
-    # Makes sure the package database is initialized.
-    def init_packager
-      Pkg.TargetInitialize(Installation.destdir)
-      Pkg.TargetLoad
-      Pkg.SourceRestore
-      Pkg.SourceLoad
-    end
   end
 
   HttpServerPackages = HttpServerPackagesClass.new

--- a/src/modules/HttpServerPackages.rb
+++ b/src/modules/HttpServerPackages.rb
@@ -1,0 +1,65 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2012 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+require "yast"
+require "y2packager/resolvable"
+
+module Yast
+  class HttpServerPackagesClass < Module
+    include Yast::Logger
+
+    def main
+      textdomain "base"
+    end
+
+    # Tries to find a package according to the pattern
+    #
+    # @param pattern [String] a regex pattern to match, no escaping done
+    # @return list of matching package names
+    def by_pattern(pattern)
+      raise ArgumentError, "Missing search pattern" if pattern.nil? || pattern.empty?
+
+      init_packager
+
+      # NOTE: - Resolvable.find takes POSIX regexp, later select uses Ruby regexp
+      # - Resolvable.find supports regexps only for dependencies, so we need to
+      # filter result according to package name
+      Y2Packager::Resolvable.find({ provides_regexp: "^#{pattern}$" }, [:name])
+        .select { |p| p.name =~ /\A#{pattern}\z/ }
+        .map(&:name)
+        .uniq
+    end
+
+    publish function: :by_pattern, type: "list <string> (string)"
+
+  private
+    # Makes sure the package database is initialized.
+    def init_packager
+      Pkg.TargetInitialize(Installation.destdir)
+      Pkg.TargetLoad
+      Pkg.SourceRestore
+      Pkg.SourceLoad
+    end
+  end
+
+  HttpServerPackages = HttpServerPackagesClass.new
+  HttpServerPackages.main
+end

--- a/src/modules/HttpServerPackages.rb
+++ b/src/modules/HttpServerPackages.rb
@@ -34,19 +34,19 @@ module Yast
     #
     # @param pattern [String] a regex pattern to match, no escaping done
     # @return list of matching package names
-    def by_pattern(pattern)
+    def by_provides_regexp(pattern)
       raise ArgumentError, "Missing search pattern" if pattern.nil? || pattern.empty?
 
       # NOTE: - Resolvable.find takes POSIX regexp, later select uses Ruby regexp
       # - Resolvable.find supports regexps only for dependencies, so we need to
       # filter result according to package name
-      Y2Packager::Resolvable.find({ provides_regexp: "^#{pattern}$" }, [:name])
+      Y2Packager::Resolvable.find({ kind: :package, provides_regexp: "^#{pattern}$" }, [])
         .select { |p| p.name =~ /\A#{pattern}\z/ }
         .map(&:name)
         .uniq
     end
 
-    publish function: :by_pattern, type: "list <string> (string)"
+    publish function: :by_provides_regexp, type: "list <string> (string)"
 
   end
 

--- a/src/modules/YaPI/HTTPD.pm
+++ b/src/modules/YaPI/HTTPD.pm
@@ -955,8 +955,9 @@ BEGIN { $TYPEINFO{GetKnownModules} = ["function", [ "list", ["map","string","any
 sub GetKnownModules {
     my $self = shift;
     my @ret = ();
-    foreach my $mod ( keys(%YaPI::HTTPDModules::modules) ) {
-        push( @ret, { name => $mod, %{$YaPI::HTTPDModules::modules{$mod}} } );
+    my %modules = YaPI::HTTPDModules::ServerModules();
+    foreach my $mod ( keys(%modules) ) {
+        push( @ret, { name => $mod, %{$modules{$mod}} } );
         @ret = sort( { $a->{position} <=> $b->{position} } @ret );
     }
     return \@ret;
@@ -984,6 +985,7 @@ sub ModifyModuleList {
     my $self = shift;
     my $newModules = shift;
     my $enable = shift;
+    my %modules = YaPI::HTTPDModules::ServerModules();
 
     my @newList = ();
     if( not $enable ) {
@@ -1001,8 +1003,8 @@ sub ModifyModuleList {
             push( @oldList, $mod );
         }
         @newList = sort( {
-                         my $aa = (exists($YaPI::HTTPDModules::modules{$a}))?($YaPI::HTTPDModules::modules{$a}->{position}):(10000000);
-                         my $bb = (exists($YaPI::HTTPDModules::modules{$b}))?($YaPI::HTTPDModules::modules{$b}->{position}):(10000000);
+                         my $aa = (exists($modules{$a}))?($modules{$a}->{position}):(10000000);
+                         my $bb = (exists($modules{$b}))?($modules{$b}->{position}):(10000000);
                          $aa <=> $bb;
                         } @oldList );
     }
@@ -1012,7 +1014,7 @@ sub ModifyModuleList {
    my @known=();
    my @unknown=();
    foreach my $module (@newList){
-    if (grep (/^$module$/, (keys %YaPI::HTTPDModules::modules))){
+    if (grep (/^$module$/, (keys %modules))){
      push(@known, $module);
     } else {
          push(@unknown, $module);
@@ -1445,9 +1447,10 @@ sub GetModulePackages {
 #    my $mods = $self->GetModuleList();
     my $mods = YaST::HTTPDData->GetModuleList();
     my %uniq;
+    my %modules = YaPI::HTTPDModules::ServerModules();
     foreach my $mod ( @$mods ) {
-    if ( exists($YaPI::HTTPDModules::modules{$mod}) ) {
-        @uniq{@{$YaPI::HTTPDModules::modules{$mod}->{packages}}} = ();
+    if ( exists($modules{$mod}) ) {
+        @uniq{@{$modules{$mod}->{packages}}} = ();
 	}
     }
     return [ keys(%uniq) ];

--- a/src/modules/YaPI/HTTPD.pm
+++ b/src/modules/YaPI/HTTPD.pm
@@ -747,8 +747,8 @@ sub CreateHost {
         # VirtualByName and SSL get dropped/replaced
         if( $key->{KEY} eq 'VirtualByName' ) {
             $VirtualByName = $key->{VALUE};
-        } 
-if( $key->{KEY} =~ /ServerTokens|TimeOut|ExtendedStatus/ ) {
+        }
+        if( $key->{KEY} =~ /ServerTokens|TimeOut|ExtendedStatus/ ) {
             # illegal keys in vhost
             return $self->SetError( summary => sprintf(__("Illegal key in virtual host '%s'."), $key->{KEY}),
                                     code    => "CHECK_PARAM_FAILED" );
@@ -1026,8 +1026,6 @@ sub ModifyModuleList {
     foreach my $module (@newList){
     	SCR->Execute('.target.bash', "a2enmod $module");
     }
-#    SCR->Write('.sysconfig.apache2.APACHE_MODULES', join(' ',@newList));
-#    SCR->Write('.sysconfig.apache2', undef);
     return 1;
 }
 
@@ -1063,67 +1061,6 @@ sub GetKnownModuleSelections {
     }
     return \@ret;
 }
-
-=item *
-C<$selList = GetModuleSelectionsList()>
-
-this function returns a reference to an array that
-contains strings with the names of the active module
-selections.
-
-EXAMPLE
-
- my $selList = GetModuleSelectionsList();
- print "active selections: ".join(',', @$selList)."\n";
-
-=cut
-
-#BEGIN { $TYPEINFO{GetModuleSelectionsList} = ["function", ["list","string"] ]; }
-#sub GetModuleSelectionsList {
-#    my $self = shift;
-#    return (SCR->Read('.http_server.moduleselection'))[0];
-#}
-
-=item *
-C<ModifyModuleSelectionList($selList, $status)>
-
-this function modifies the module selection list.
-You can turn on and off module selections with the
-boolean $status.
-Changing the selections will directly influence the
-module list.
-
-EXAMPLE
-
- ModifyModuleSelectionList( ['perl-scripting', 'debug'],1  );
- ModifyModuleSelectionList( ['php4-scripting'], 0 );
-
-=cut
-
-#BEGIN { $TYPEINFO{ModifyModuleSelectionList} = ["function", "boolean", ["list","string"], "boolean" ]; }
-#sub ModifyModuleSelectionList {
-#    my $self = shift;
-#    my $newSelection = shift;
-#    my $enable = shift;
-#    my %uniq = ();
-
-#    @uniq{@{$self->GetModuleSelectionsList()}} = ();
-#    if( $enable ) {
-#        @uniq{@$newSelection} = ();
-#        foreach my $ns ( @$newSelection ) {
-#            $self->ModifyModuleList( $HTTPModules::selection{$ns}->{modules}, 1 );
-#            $self->ModifyModuleList( [], 1 );
-#        }
-#    } else {
-#        delete(@uniq{@$newSelection});
-#        foreach my $ns ( @$newSelection ) {
-#            $self->ModifyModuleList( $HTTPModules::selection{$ns}->{modules}, 0 );
-#            $self->ModifyModuleList( [], 1 );
-#        }
-#    }
-
-#    SCR->Write('.http_server.moduleselection', [keys(%uniq)]);
-#}
 
 #######################################################
 # apache2 modules API end
@@ -1444,7 +1381,6 @@ EXAMPLE
 BEGIN { $TYPEINFO{GetModulePackages} = ["function", ["list", "string"] ]; }
 sub GetModulePackages {
     my $self = shift;
-#    my $mods = $self->GetModuleList();
     my $mods = YaST::HTTPDData->GetModuleList();
     my %uniq;
     my %modules = YaPI::HTTPDModules::ServerModules();

--- a/src/modules/YaPI/HTTPDModules.pm
+++ b/src/modules/YaPI/HTTPDModules.pm
@@ -780,7 +780,7 @@ sub ServerModules {
         %modules = ( %modules,
             'php' . $php_version => {
                     summary   => __("Provides support for PHP dynamically generated pages"),
-                    packages  => ["apache2-mod_php" . YaST::HTTPDPhpModule->Version()],
+                    packages  => ["apache2-mod_php" . $php_version],
                     default   => 0,
                     position  => 490
             }

--- a/src/modules/YaPI/HTTPDModules.pm
+++ b/src/modules/YaPI/HTTPDModules.pm
@@ -3,6 +3,8 @@ use YaPI;
 use YaST::HTTPDPhpModule;
 
 textdomain "http-server";
+
+$php_version = YaST::HTTPDPhpModule->Version();
 %modules = (
 # (without_leading mod_) module name = {
 #	summary   => __("Translatable text with module description - will be shown in YaST table"),
@@ -708,12 +710,6 @@ textdomain "http-server";
                                    { option =>"VirtualScriptAliasIP",     "context" => [ "Server", "Virtual", "Directory" ] }
 				]
     },
-    'php' . YaST::HTTPDPhpModule->Version() => {
-                    summary   => __("Provides support for PHP dynamically generated pages"),
-                    packages  => ["apache2-mod_php" . YaST::HTTPDPhpModule->Version()],
-                    default   => 0,
-                    position  => 490
-    },
     'perl' => {
                     summary   => __("Provides support for Perl dynamically generated pages"),
                     packages  => ["apache2-mod_perl"],
@@ -768,6 +764,19 @@ textdomain "http-server";
      }
 
 );
+
+if($php_version)
+{
+  %modules = ( %modules,
+    'php' . $php_version => {
+                    summary   => __("Provides support for PHP dynamically generated pages"),
+                    packages  => ["apache2-mod_php" . YaST::HTTPDPhpModule->Version()],
+                    default   => 0,
+                    position  => 490
+    }
+  );
+}
+
 %selection = (
     TestSel => {
                 summary => 'A test selection',

--- a/src/modules/YaPI/HTTPDModules.pm
+++ b/src/modules/YaPI/HTTPDModules.pm
@@ -4,7 +4,6 @@ use YaST::HTTPDPhpModule;
 
 textdomain "http-server";
 
-$php_version = YaST::HTTPDPhpModule->Version();
 %modules = (
 # (without_leading mod_) module name = {
 #	summary   => __("Translatable text with module description - will be shown in YaST table"),
@@ -765,18 +764,6 @@ $php_version = YaST::HTTPDPhpModule->Version();
 
 );
 
-if($php_version)
-{
-  %modules = ( %modules,
-    'php' . $php_version => {
-                    summary   => __("Provides support for PHP dynamically generated pages"),
-                    packages  => ["apache2-mod_php" . YaST::HTTPDPhpModule->Version()],
-                    default   => 0,
-                    position  => 490
-    }
-  );
-}
-
 %selection = (
     TestSel => {
                 summary => 'A test selection',
@@ -784,3 +771,19 @@ if($php_version)
                 default => 0
     }
 );
+
+BEGIN { $TYPEINFO{ServerModules} = ["function", ["map","string","any"] ]; }
+sub ServerModules {
+    $php_version = YaST::HTTPDPhpModule->Version();
+    if($php_version)
+    {
+        %modules = ( %modules,
+            'php' . $php_version => {
+                    summary   => __("Provides support for PHP dynamically generated pages"),
+                    packages  => ["apache2-mod_php" . YaST::HTTPDPhpModule->Version()],
+                    default   => 0,
+                    position  => 490
+            }
+        );
+     }
+}

--- a/src/modules/YaST/HTTPDData.pm
+++ b/src/modules/YaST/HTTPDData.pm
@@ -609,9 +609,10 @@ sub GetPackagesForModule {
     my $self = shift;
     my $mod = shift;
     my %uniq;
+    my %modules = YaPI::HTTPDModules::ServerModules();
 
-    if ( exists($YaPI::HTTPDModules::modules{$mod}) ) {
-	@uniq{@{$YaPI::HTTPDModules::modules{$mod}->{packages}}} = ();
+    if ( exists($modules{$mod}) ) {
+	@uniq{@{$modules{$mod}->{packages}}} = ();
 }
     return [ keys(%uniq) ];
 }

--- a/src/modules/YaST/HTTPDPhpModule.pm
+++ b/src/modules/YaST/HTTPDPhpModule.pm
@@ -12,7 +12,7 @@ sub Version {
     # when function returns an array, we get reference to it
     $l = Package->by_pattern("php[0-9]{1,2}");
 
-    return "" if(!$l);
+    return if(!$l);
 
     # there can be multiple versions of php and
     # package name is php<version>. We're interested in <version> only

--- a/src/modules/YaST/HTTPDPhpModule.pm
+++ b/src/modules/YaST/HTTPDPhpModule.pm
@@ -1,11 +1,27 @@
 package YaST::HTTPDPhpModule;
 
+use YaST::YCP;
+
+YaST::YCP::Import "Package";
+
 our %TYPEINFO;
 
 # Define globally the current PHP version
 BEGIN { $TYPEINFO{Version} = ["function", "string" ]; }
 sub Version {
-    return "7";
+    # when function returns an array, we get reference to it
+    $l = Package->by_pattern("php[0-9]");
+
+    return "" if(!$l);
+
+    # there can be multiple versions of php
+    @{$l} = sort @{$l};
+
+    # package name is php<version> and we're interested in <version> only
+    # we also take highest available version
+    $l->[-1] =~ s/php([0-9]{1,2})$/$1/;
+
+    return $l->[-1];
 }
 
 1;

--- a/src/modules/YaST/HTTPDPhpModule.pm
+++ b/src/modules/YaST/HTTPDPhpModule.pm
@@ -10,7 +10,7 @@ our %TYPEINFO;
 BEGIN { $TYPEINFO{Version} = ["function", "string" ]; }
 sub Version {
     # when function returns an array, we get reference to it
-    $l = HttpServerPackages->by_pattern("php[0-9]{1,2}");
+    $l = HttpServerPackages->by_provides_regexp("php[0-9]{1,2}");
 
     return if(!$l);
 

--- a/src/modules/YaST/HTTPDPhpModule.pm
+++ b/src/modules/YaST/HTTPDPhpModule.pm
@@ -10,18 +10,17 @@ our %TYPEINFO;
 BEGIN { $TYPEINFO{Version} = ["function", "string" ]; }
 sub Version {
     # when function returns an array, we get reference to it
-    $l = Package->by_pattern("php[0-9]");
+    $l = Package->by_pattern("php[0-9]{1,2}");
 
     return "" if(!$l);
 
-    # there can be multiple versions of php
-    @{$l} = sort @{$l};
+    # there can be multiple versions of php and
+    # package name is php<version>. We're interested in <version> only
+    # Take highest available version
+    @s = map { int($_ =~ s/php([0-9]{1,2})$/$1/r) } @{$l};
+    @s = sort {$a <=> $b} @s;
 
-    # package name is php<version> and we're interested in <version> only
-    # we also take highest available version
-    $l->[-1] =~ s/php([0-9]{1,2})$/$1/;
-
-    return $l->[-1];
+    return $s[-1];
 }
 
 1;

--- a/src/modules/YaST/HTTPDPhpModule.pm
+++ b/src/modules/YaST/HTTPDPhpModule.pm
@@ -2,7 +2,7 @@ package YaST::HTTPDPhpModule;
 
 use YaST::YCP;
 
-YaST::YCP::Import "Package";
+YaST::YCP::Import "HttpServerPackages";
 
 our %TYPEINFO;
 
@@ -10,7 +10,7 @@ our %TYPEINFO;
 BEGIN { $TYPEINFO{Version} = ["function", "string" ]; }
 sub Version {
     # when function returns an array, we get reference to it
-    $l = Package->by_pattern("php[0-9]{1,2}");
+    $l = HttpServerPackages->by_pattern("php[0-9]{1,2}");
 
     return if(!$l);
 

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -7,11 +7,11 @@ describe "Yast::HttpServerRoutinesInclude" do
   before(:each) do
     # deep in HttpServer module is buried code which builds list of modules
     # and it uses Package module to query available packages
-    Yast.import "Package"
+    Yast.import "HttpServerPackages"
     Yast.import "HttpServer"
 
-    allow(Yast::Package)
-      .to receive(:by_pattern)
+    allow(Yast::HttpServerPackages)
+      .to receive(:by_provides_regexp)
       .and_return(["php8"])
   end
 

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -3,9 +3,18 @@
 require_relative "test_helper"
 require "yast"
 
-Yast.import "HttpServer"
+describe "Yast::HttpServerRoutinesInclude" do
+  before(:each) do
+    # deep in HttpServer module is buried code which builds list of modules
+    # and it uses Package module to query available packages
+    Yast.import "Package"
+    Yast.import "HttpServer"
 
-describe Yast::HttpServerRoutinesInclude do
+    allow(Yast::Package)
+      .to receive(:by_pattern)
+      .and_return(["php8"])
+  end
+
   # it is included in http server module
   subject { Yast::HttpServer }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,10 +46,10 @@ if ENV["COVERAGE"]
       c.single_report_path = "coverage/lcov.info"
     end
 
-    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
       SimpleCov::Formatter::HTMLFormatter,
       SimpleCov::Formatter::LcovFormatter
-    ]
+    ])
   end
 end
 


### PR DESCRIPTION
## Problem

Php version was hardcoded. It caused troubles when php got new major update (php7 -> php8)

- https://bugzilla.suse.com/show_bug.cgi?id=1200016
- https://github.com/yast/yast-yast2/pull/1262

## Solution

Use newly implemented package search (see the referenced PR) for finding out accurate PHP version


## Testing

- Covered by existing tests
- *Tested manually*


